### PR TITLE
Fixed try without catch per ES specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function findGlobals(source) {
       parent.locals[node.id.name] = true;
     },
     'TryStatement': function (node) {
-      if(node.handler === null) return;
+      if (node.handler === null) return;
       node.handler.body.locals = node.handler.body.locals || {};
       node.handler.body.locals[node.handler.param.name] = true;
     },

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ function findGlobals(source) {
       parent.locals[node.id.name] = true;
     },
     'TryStatement': function (node) {
+      if(node.handler === null) return;
       node.handler.body.locals = node.handler.body.locals || {};
       node.handler.body.locals[node.handler.param.name] = true;
     },


### PR DESCRIPTION
Currently, the implementation for 'TryStatement' is broken. If there is no **catch** block present, it will die on line 118 `Cannot read property 'body' of null`.

As per ES3 and [ES5](https://es5.github.io/#x12.14) specification:

	TryStatement :
	* try Block Catch
	* try Block Finally
	* try Block Catch Finally

Therefore, we should validate that a catch block is present, and if not, return.

To reproduce, have acorn-globals parse this valid JS: `try { var x = 3; } finally { x = 0; }`