### PR TITLE
Revert `this` behaviour for backwards compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ function declaresArguments(node) {
   return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration';
 }
 
+function declaresThis(node) {
+  return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration';
+}
+
 function reallyParse(source) {
   try {
     return acorn.parse(source, {
@@ -154,7 +158,16 @@ function findGlobals(source) {
   }
   walk.ancestor(ast, {
     'VariablePattern': identifier,
-    'Identifier': identifier
+    'Identifier': identifier,
+    'ThisExpression': function (node, parents) {
+      for (var i = 0; i < parents.length; i++) {
+        if (declaresThis(parents[i])) {
+          return;
+        }
+      }
+      node.parents = parents;
+      globals.push(node);
+    }
   });
   var groupedGlobals = {};
   globals.forEach(function (node) {

--- a/test/fixtures/this.js
+++ b/test/fixtures/this.js
@@ -1,0 +1,1 @@
+return this.foo;

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,8 @@ test('assign_implicit.js - assign from an implicit global', function () {
   assert.deepEqual(detect(read('assign_implicit.js')).map(function (node) { return node.name; }), ['bar']);
 });
 test('class.js - ES2015 classes', function () {
-  assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), ['OtherClass_', 'SuperClass'].sort());
+  // TODO: `'undefined'` should be `this` but preserved for backwards compatability
+  assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), ['OtherClass_', 'SuperClass', 'undefined'].sort());
 });
 test('default-argument.js - ES2015 default argument', function () {
   assert.deepEqual(detect(read('default-argument.js')).map(function (node) { return node.name; }), ['c', 'h', 'j', 'k']);
@@ -64,4 +65,8 @@ test('right_hand.js - globals on the right-hand of assignment', function () {
 });
 test('try_catch.js - the exception in a try catch block is a local', function () {
   assert.deepEqual(detect(read('try_catch.js')), []);
+});
+test('this.js - `this` is considered a global', function () {
+  // TODO: `'undefined'` should be `this` but preserved for backwards compatability
+  assert.deepEqual(detect(read('this.js')).map(function (node) { return node.name; }), ['undefined']);
 });


### PR DESCRIPTION
This behaviour is buggy, but changing it was a breaking change.  We
will keep this buggy behaviour for v1 and fix the bug in v2