### PR TITLE
add includeFileVars option for file-scope globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ var detect = require('acorn-globals');
 
 var src = fs.readFileSync(__dirname + '/input.js', 'utf8');
 
-var scope = detect(src, {includeFileVars: false});
+var options = {};
+var scope = detect(src, options);
 console.dir(scope);
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ $ node example/detect.js
     Include variables declared in the file scope of the JavaScript file.
     This is useful when using modules that are not automatically wrapped in a closure.
 
+  - `includeFunctionDeclarations`
+
+    Default: `false`
+
+    Include function definitions in the list of globals. Use with `includeFileVars`.
+
 ## License
 
   MIT

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var detect = require('acorn-globals');
 
 var src = fs.readFileSync(__dirname + '/input.js', 'utf8');
 
-var scope = detect(src);
+var scope = detect(src, {includeFileVars: false});
 console.dir(scope);
 ```
 
@@ -70,6 +70,14 @@ $ node example/detect.js
   { name: 'xyz', nodes: [ [Object] ] } ]
 ```
 
+## Options
+
+  - `includeFileVars`
+
+    Default: `false`
+
+    Include variables declared in the file scope of the JavaScript file.
+    This is useful when using modules that are not automatically wrapped in a closure.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function findGlobals(source, options) {
 
   options = options || {};
   options.includeFileVars = options.includeFileVars || false;
+  options.includeFunctionDeclarations = options.includeFunctionDeclarations || false;
 
   // istanbul ignore else
   if (typeof source === 'string') {
@@ -145,7 +146,10 @@ function findGlobals(source, options) {
       if (name === 'arguments' && declaresArguments(parents[i])) {
         return;
       }
-      if (!(options.includeFileVars && parents[i].type === 'Program')) {
+
+      var parentIsGlobalScopeAndEnabled = (options.includeFileVars && parents[i].type === 'Program');
+      var parentIsFunctionDeclarationAndEnabled = (options.includeFunctionDeclarations && parents[i].type === 'FunctionDeclaration' && i === parents.length - 2 && node === parents[i].id);
+      if (!parentIsGlobalScopeAndEnabled && !parentIsFunctionDeclarationAndEnabled) {
         if (parents[i].locals && name in parents[i].locals) {
           return;
         }

--- a/index.js
+++ b/index.js
@@ -37,9 +37,13 @@ function reallyParse(source) {
 }
 module.exports = findGlobals;
 module.exports.parse = reallyParse;
-function findGlobals(source) {
+function findGlobals(source, options) {
   var globals = [];
   var ast;
+
+  options = options || {};
+  options.includeFileVars = options.includeFileVars || false;
+
   // istanbul ignore else
   if (typeof source === 'string') {
     ast = reallyParse(source);
@@ -141,8 +145,10 @@ function findGlobals(source) {
       if (name === 'arguments' && declaresArguments(parents[i])) {
         return;
       }
-      if (parents[i].locals && name in parents[i].locals) {
-        return;
+      if (!(options.includeFileVars && parents[i].type === 'Program')) {
+        if (parents[i].locals && name in parents[i].locals) {
+          return;
+        }
       }
     }
     if (

--- a/test/fixtures/detect.js
+++ b/test/fixtures/detect.js
@@ -27,6 +27,8 @@ foo(function () {
 
 });
 
-function beep () {}
+function beep () {
+  function boop() {}
+}
 
 console.log(xyz);

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,8 @@ test('detect.js - check locals and globals', function () {
                    ['w', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort());
   assert.deepEqual(detect(read('detect.js'), {includeFileVars: true}).map(function (node) { return node.name; }),
                    ['w', 'x', 'y', 'z', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort());
+  assert.deepEqual(detect(read('detect.js'), {includeFileVars: true, includeFunctionDeclarations: true}).map(function (node) { return node.name; }),
+                   ['w', 'x', 'y', 'z', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR', 'beep'].sort());
 });
 test('export.js - Anything that has been imported is not a global', function () {
   assert.deepEqual(detect(read('export.js')).map(function (node) { return node.name; }), ['baz']);

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,8 @@ test('destructuring.js - ES2015 variable destructuring', function () {
 test('detect.js - check locals and globals', function () {
   assert.deepEqual(detect(read('detect.js')).map(function (node) { return node.name; }),
                    ['w', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort());
+  assert.deepEqual(detect(read('detect.js'), {includeFileVars: true}).map(function (node) { return node.name; }),
+                   ['w', 'x', 'y', 'z', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort());
 });
 test('export.js - Anything that has been imported is not a global', function () {
   assert.deepEqual(detect(read('export.js')).map(function (node) { return node.name; }), ['baz']);


### PR DESCRIPTION
Some module systems do not wrap the module code in closures, so variables declared with `var` at the file level become global variables. Simple concatenated scripts have this behavior, for example.

This PR adds a backward-compatible option to enable including these global variables. Tests and documentation are included.
