### PR TITLE
Update acorn to ^3.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,21 +19,11 @@ function declaresThis(node) {
 }
 
 function reallyParse(source) {
-  try {
-    return acorn.parse(source, {
-      ecmaVersion: 6,
-      allowReturnOutsideFunction: true,
-      allowImportExportEverywhere: true,
-      allowHashBang: true
-    });
-  } catch (ex) {
-    return acorn.parse(source, {
-      ecmaVersion: 5,
-      allowReturnOutsideFunction: true,
-      allowImportExportEverywhere: true,
-      allowHashBang: true
-    });
-  }
+  return acorn.parse(source, {
+    allowReturnOutsideFunction: true,
+    allowImportExportEverywhere: true,
+    allowHashBang: true
+  });
 }
 module.exports = findGlobals;
 module.exports.parse = reallyParse;
@@ -127,8 +117,8 @@ function findGlobals(source) {
     },
     'TryStatement': function (node) {
       if (node.handler === null) return;
-      node.handler.body.locals = node.handler.body.locals || {};
-      node.handler.body.locals[node.handler.param.name] = true;
+      node.handler.locals = node.handler.locals || {};
+      node.handler.locals[node.handler.param.name] = true;
     },
     'ImportDefaultSpecifier': declareModuleSpecifier,
     'ImportSpecifier': declareModuleSpecifier,
@@ -144,14 +134,6 @@ function findGlobals(source) {
       if (parents[i].locals && name in parents[i].locals) {
         return;
       }
-    }
-    if (
-      parents[parents.length - 2] &&
-      parents[parents.length - 2].type === 'TryStatement' &&
-      parents[parents.length - 2].handler &&
-      node === parents[parents.length - 2].handler.param
-    ) {
-      return;
     }
     node.parents = parents;
     globals.push(node);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "acorn": "^2.1.0"
+    "acorn": "^3.1.0"
   },
   "devDependencies": {
     "testit": "^2.0.2"


### PR DESCRIPTION
First, the ES5 fallback in `reallyParse` is now unnecessary because the bug is now fixed in acorn, although a major bump is required since ES6 and ES5 are not fully compatible.

Second, a bug-fix in the AST walker made the walker now go through CatchClause as well, changing the number of parents before the `param` property while making it possible to attach the locals on the entire CatchClause, which is a cleaner solution.