### PR TITLE
Added location object to parsed ast

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function reallyParse(source) {
   return acorn.parse(source, {
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
-    allowHashBang: true
+    allowHashBang: true,
+    locations: true
   });
 }
 module.exports = findGlobals;


### PR DESCRIPTION
locations: When true, each node has a loc object attached with start and end subobjects, each of which contains the one-based line and zero-based column numbers in {line, column} form. Default is false.
This will help us to find the line number of the globals