### PR TITLE
Added locations to acorn return

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function reallyParse(source) {
   return acorn.parse(source, {
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
-    allowHashBang: true
+    allowHashBang: true,
+    locations: true
   });
 }
 module.exports = findGlobals;


### PR DESCRIPTION
This would be nice to have acorn return the location identifiers for nodes returned.