### PR TITLE
Ensure parents array survives the call to walk.ancestor

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,10 +135,7 @@ function findGlobals(source) {
         return;
       }
     }
-    node.parents = [];
-    for (var j = 0; j < parents.length; j++) {
-      node.parents.push(parents[j]);
-    }
+    node.parents = parents.slice();
     globals.push(node);
   }
   walk.ancestor(ast, {
@@ -150,10 +147,7 @@ function findGlobals(source) {
           return;
         }
       }
-      node.parents = [];
-      for (var j = 0; j < parents.length; j++) {
-        node.parents.push(parents[j]);
-      }
+      node.parents = parents.slice();
       globals.push(node);
     }
   });

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function findGlobals(source) {
     if (node.id) {
       fn.locals[node.id.name] = true;
     }
-  }
+  };
   var declarePattern = function (node, parent) {
     switch (node.type) {
       case 'Identifier':
@@ -75,11 +75,11 @@ function findGlobals(source) {
       default:
         throw new Error('Unrecognized pattern type: ' + node.type);
     }
-  }
+  };
   var declareModuleSpecifier = function (node, parents) {
     ast.locals = ast.locals || {};
     ast.locals[node.local.name] = true;
-  }
+  };
   walk.ancestor(ast, {
     'VariableDeclaration': function (node, parents) {
       var parent = null;
@@ -135,7 +135,10 @@ function findGlobals(source) {
         return;
       }
     }
-    node.parents = parents;
+    node.parents = [];
+    for (var j = 0; j < parents.length; j++) {
+      node.parents.push(parents[j]);
+    }
     globals.push(node);
   }
   walk.ancestor(ast, {
@@ -147,7 +150,10 @@ function findGlobals(source) {
           return;
         }
       }
-      node.parents = parents;
+      node.parents = [];
+      for (var j = 0; j < parents.length; j++) {
+        node.parents.push(parents[j]);
+      }
       globals.push(node);
     }
   });

--- a/test/fixtures/properties.js
+++ b/test/fixtures/properties.js
@@ -1,0 +1,12 @@
+var simple = {};
+var qualified = {
+    nested: {}
+};
+
+simple_g = {};
+qualified_g = {
+    nested: {}
+};
+ugly.chained.methodCall();
+ugly.chained.lookup = {};
+var shim = uglier.chained.property.lookup;


### PR DESCRIPTION
Recent versions of acorn have been deleting entries from the array passed to walk.ancestor, meaning the parents metadata was always empty after running acorn-globals. This PR fixes this issue