### PR TITLE
fix: make names in Object.prototype work right

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function findGlobals(source, options) {
   }
   var declareFunction = function (node) {
     var fn = node;
-    fn.locals = fn.locals || {};
+    fn.locals = fn.locals || Object.create(null);
     node.params.forEach(function (node) {
       declarePattern(node, fn);
     });
@@ -81,7 +81,7 @@ function findGlobals(source, options) {
     }
   };
   var declareModuleSpecifier = function (node, parents) {
-    ast.locals = ast.locals || {};
+    ast.locals = ast.locals || Object.create(null);
     ast.locals[node.local.name] = true;
   };
   walk.ancestor(ast, {
@@ -92,7 +92,7 @@ function findGlobals(source, options) {
           parent = parents[i];
         }
       }
-      parent.locals = parent.locals || {};
+      parent.locals = parent.locals || Object.create(null);
       node.declarations.forEach(function (declaration) {
         declarePattern(declaration.id, parent);
       });
@@ -104,7 +104,7 @@ function findGlobals(source, options) {
           parent = parents[i];
         }
       }
-      parent.locals = parent.locals || {};
+      parent.locals = parent.locals || Object.create(null);
       if (node.id) {
         parent.locals[node.id.name] = true;
       }
@@ -118,14 +118,14 @@ function findGlobals(source, options) {
           parent = parents[i];
         }
       }
-      parent.locals = parent.locals || {};
+      parent.locals = parent.locals || Object.create(null);
       if (node.id) {
         parent.locals[node.id.name] = true;
       }
     },
     'TryStatement': function (node) {
       if (node.handler === null) return;
-      node.handler.locals = node.handler.locals || {};
+      node.handler.locals = node.handler.locals || Object.create(null);
       node.handler.locals[node.handler.param.name] = true;
     },
     'ImportDefaultSpecifier': declareModuleSpecifier,
@@ -159,7 +159,7 @@ function findGlobals(source, options) {
       globals.push(node);
     }
   });
-  var groupedGlobals = {};
+  var groupedGlobals = Object.create(null);
   globals.forEach(function (node) {
     var name = node.type === 'ThisExpression' ? 'this' : node.name;
     groupedGlobals[name] = (groupedGlobals[name] || []);

--- a/test/fixtures/names-in-object-prototype.js
+++ b/test/fixtures/names-in-object-prototype.js
@@ -1,0 +1,3 @@
+hasOwnProperty;
+constructor;
+__proto__;

--- a/test/fixtures/names-in-object-prototype.js
+++ b/test/fixtures/names-in-object-prototype.js
@@ -1,9 +1,9 @@
 {
-  let toString;
-  toString;
+  let valueOf;
+  valueOf;
 }
-let valueOf;
-valueOf;
+let toString;
+toString;
 hasOwnProperty;
 constructor;
 __proto__;

--- a/test/fixtures/names-in-object-prototype.js
+++ b/test/fixtures/names-in-object-prototype.js
@@ -1,3 +1,9 @@
+{
+  let toString;
+  toString;
+}
+let valueOf;
+valueOf;
 hasOwnProperty;
 constructor;
 __proto__;

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,9 @@ test('multiple-exports.js - multiple-exports', function () {
 test('named_arg.js - named argument / parameter', function () {
   assert.deepEqual(detect(read('named_arg.js')), []);
 });
+test('names-in-object-prototype.js - check names in object prototype', function () {
+  assert.deepEqual(detect(read('names-in-object-prototype.js')), ['hasOwnProperty', 'constructor', '__proto__']);
+});
 test('obj.js - globals on the right-hand of a colon in an object literal', function () {
   assert.deepEqual(detect(read('obj.js')).map(function (node) { return node.name; }), ['bar', 'module']);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ test('named_arg.js - named argument / parameter', function () {
   assert.deepEqual(detect(read('named_arg.js')), []);
 });
 test('names-in-object-prototype.js - check names in object prototype', function () {
-  assert.deepEqual(detect(read('names-in-object-prototype.js')), ['hasOwnProperty', 'constructor', '__proto__']);
+  assert.deepEqual(detect(read('names-in-object-prototype.js')).map(function (node) { return node.name; }).sort(), ['__proto__', 'constructor', 'hasOwnProperty']);
 });
 test('obj.js - globals on the right-hand of a colon in an object literal', function () {
   assert.deepEqual(detect(read('obj.js')).map(function (node) { return node.name; }), ['bar', 'module']);


### PR DESCRIPTION
```js
const detect = require('acorn-globals');
detect('toString');
```

```
/node_modules/acorn-globals/index.js:166
    groupedGlobals[name].push(node);
                         ^
```

```
TypeError: groupedGlobals[name].push is not a function
    at /node_modules/acorn-globals/index.js:166:26
    at Array.forEach (<anonymous>)
    at findGlobals (/node_modules/acorn-globals/index.js:163:11)
    at Object.<anonymous> (/test.js:2:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
```