### PR TITLE
add pattern support for catch & try to beautify test

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function findGlobals(source, options) {
     'TryStatement': function (node) {
       if (node.handler === null) return;
       node.handler.locals = node.handler.locals || Object.create(null);
-      node.handler.locals[node.handler.param.name] = true;
+      declarePattern(node.handler.param, node.handler);
     },
     'ImportDefaultSpecifier': declareModuleSpecifier,
     'ImportSpecifier': declareModuleSpecifier,

--- a/test/fixtures/catch-pattern.js
+++ b/test/fixtures/catch-pattern.js
@@ -1,2 +1,2 @@
 try { }
-catch ({ message }) { message; undefined; }
+catch ({ message }) { message; }

--- a/test/fixtures/catch-pattern.js
+++ b/test/fixtures/catch-pattern.js
@@ -1,0 +1,2 @@
+try { }
+catch ({ message }) { message; undefined; }

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ test('arrow_functions.js - arguments of arrow functions are not globals', functi
 test('assign_implicit.js - assign from an implicit global', function () {
   assert.deepEqual(detect(read('assign_implicit.js')).map(function (node) { return node.name; }), ['bar']);
 });
-test('catch-pattern.js', function () {
+test('catch-pattern.js - pattern in catch', function () {
   assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), []);
 });
 test('class.js - ES2015 classes', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,9 @@ test('arrow_functions.js - arguments of arrow functions are not globals', functi
 test('assign_implicit.js - assign from an implicit global', function () {
   assert.deepEqual(detect(read('assign_implicit.js')).map(function (node) { return node.name; }), ['bar']);
 });
+test('catch-pattern.js', function () {
+  assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), []);
+});
 test('class.js - ES2015 classes', function () {
   assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), ['G', 'OtherClass_', 'SuperClass', 'this'].sort());
 });

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ test('assign_implicit.js - assign from an implicit global', function () {
   assert.deepEqual(detect(read('assign_implicit.js')).map(function (node) { return node.name; }), ['bar']);
 });
 test('catch-pattern.js - pattern in catch', function () {
-  assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), []);
+  assert.deepEqual(detect(read('catch-pattern.js')).map(function (node) { return node.name; }), []);
 });
 test('class.js - ES2015 classes', function () {
   assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), ['G', 'OtherClass_', 'SuperClass', 'this'].sort());

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,11 @@ function read(file) {
   return fs.readFileSync(path.resolve(__dirname + '/fixtures/', file), 'utf8');
 }
 
-var buildQualifiedVariableName = function(node) {
+function nameOf(node) {
+  return node.name;
+}
+
+function buildQualifiedVariableName(node) {
   const namePath = [];
   for (var i = node.parents.length - 1; i >= 0; i--) {
     const parent = node.parents[i];
@@ -25,52 +29,61 @@ var buildQualifiedVariableName = function(node) {
     }
   }
   return namePath.join('.');
-};
+}
 
 test('argument.js - parameters from inline arguments', function () {
   assert.deepEqual(detect(read('argument.js')), []);
 });
 test('arrow_functions.js - arguments of arrow functions are not globals', function () {
-  assert.deepEqual(detect(read('arrow_functions.js')).map(function (node) { return node.name; }), ['z', 'b', 'c', 'arguments'].sort());
+  assert.deepEqual(detect(read('arrow_functions.js')).map(nameOf), ['z', 'b', 'c', 'arguments'].sort());
 });
 test('assign_implicit.js - assign from an implicit global', function () {
-  assert.deepEqual(detect(read('assign_implicit.js')).map(function (node) { return node.name; }), ['bar']);
+  assert.deepEqual(detect(read('assign_implicit.js')).map(nameOf), ['bar']);
 });
 test('catch-pattern.js - pattern in catch', function () {
-  assert.deepEqual(detect(read('catch-pattern.js')).map(function (node) { return node.name; }), []);
+  assert.deepEqual(detect(read('catch-pattern.js')), []);
 });
 test('class.js - ES2015 classes', function () {
-  assert.deepEqual(detect(read('class.js')).map(function (node) { return node.name; }), ['G', 'OtherClass_', 'SuperClass', 'this'].sort());
+  assert.deepEqual(detect(read('class.js')).map(nameOf), ['G', 'OtherClass_', 'SuperClass', 'this'].sort());
 });
 test('class-expression.js - class as expression', function () {
   assert.deepEqual(detect(read('class-expression.js')), []);
 });
 test('default-argument.js - ES2015 default argument', function () {
-  assert.deepEqual(detect(read('default-argument.js')).map(function (node) { return node.name; }), ['c', 'h', 'j', 'k']);
+  assert.deepEqual(detect(read('default-argument.js')).map(nameOf), ['c', 'h', 'j', 'k']);
 });
 test('destructuring-rest.js - ES2015 destructuring rest', function () {
   assert.deepEqual(detect(read('destructuring-rest.js')), []);
 });
 test('destructuring.js - ES2015 variable destructuring', function () {
-  assert.deepEqual(detect(read('destructuring.js')).map(function (node) { return node.name; }), ['g']);
+  assert.deepEqual(detect(read('destructuring.js')).map(nameOf), ['g']);
 });
 test('detect.js - check locals and globals', function () {
-  assert.deepEqual(detect(read('detect.js')).map(function (node) { return node.name; }),
-                   ['w', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort());
+  assert.deepEqual(
+    detect(read('detect.js')).map(nameOf),
+    ['w', 'foo', 'process', 'console', 'AAA', 'BBB', 'CCC', 'xyz', 'ZZZ', 'BLARG', 'RAWR'].sort()
+  );
 });
 test('detect.js - check variable names', function () {
-    assert.deepEqual(detect(read('detect.js')).map(function (node) {
-      return '[' + node.nodes.map(function (n) { return buildQualifiedVariableName(n); }) + ']';
-    }),
-        [
-            '[w.foo,w]', '[foo]', '[process.nextTick]',
-            '[console.log,console.log]', '[AAA.aaa]',
-            '[BBB.bbb]', '[CCC.x]', '[xyz]',
-            '[ZZZ,ZZZ.foo]', '[BLARG]',
-            '[RAWR,RAWR.foo]'].sort());
+  assert.deepEqual(
+    detect(read('detect.js')).map(function (node) { return '[' + node.nodes.map(buildQualifiedVariableName) + ']'; }),
+    [
+      '[w.foo,w]',
+      '[foo]',
+      '[process.nextTick]',
+      '[console.log,console.log]',
+      '[AAA.aaa]',
+      '[BBB.bbb]',
+      '[CCC.x]',
+      '[xyz]',
+      '[ZZZ,ZZZ.foo]',
+      '[BLARG]',
+      '[RAWR,RAWR.foo]'
+    ].sort()
+  );
 });
 test('export.js - Anything that has been imported is not a global', function () {
-  assert.deepEqual(detect(read('export.js')).map(function (node) { return node.name; }), ['baz']);
+  assert.deepEqual(detect(read('export.js')).map(nameOf), ['baz']);
 });
 test('export-default-anonymous-class.js - export anonymous class as default', function () {
   assert.deepEqual(detect(read('export-default-anonymous-class.js')), []);
@@ -79,37 +92,36 @@ test('export-default-anonymous-function.js - export anonymous function as defaul
   assert.deepEqual(detect(read('export-default-anonymous-function.js')), []);
 });
 test('import.js - Anything that has been imported is not a global', function () {
-  assert.deepEqual(detect(read('import.js')).map(function (node) { return node.name; }), ['whatever']);
+  assert.deepEqual(detect(read('import.js')).map(nameOf), ['whatever']);
 });
 test('labels.js - labels for while loops are not globals', function () {
   assert.deepEqual(detect(read('labels.js')), []);
 });
 test('multiple-exports.js - multiple-exports', function () {
-  assert.deepEqual(detect(read('multiple-exports.js')).map(function (node) { return node.name; }), ['bar', 'exports']);
+  assert.deepEqual(detect(read('multiple-exports.js')).map(nameOf), ['bar', 'exports']);
 });
 test('named_arg.js - named argument / parameter', function () {
   assert.deepEqual(detect(read('named_arg.js')), []);
 });
 test('names-in-object-prototype.js - check names in object prototype', function () {
-  assert.deepEqual(detect(read('names-in-object-prototype.js')).map(function (node) { return node.name; }).sort(), ['__proto__', 'constructor', 'hasOwnProperty']);
+  assert.deepEqual(detect(read('names-in-object-prototype.js')).map(nameOf).sort(), ['__proto__', 'constructor', 'hasOwnProperty']);
 });
 test('obj.js - globals on the right-hand of a colon in an object literal', function () {
-  assert.deepEqual(detect(read('obj.js')).map(function (node) { return node.name; }), ['bar', 'module']);
+  assert.deepEqual(detect(read('obj.js')).map(nameOf), ['bar', 'module']);
 });
 test('properties.js - check variable names', function () {
-
-    assert.deepEqual(detect(read('properties.js')).map(function (node) {
-            return '[' + node.nodes.map(function (n) { return buildQualifiedVariableName(n); }) + ']';
-        }),
-        [
-            '[simple_g]',
-            '[qualified_g]',
-            '[ugly.chained.methodCall,ugly.chained.lookup]',
-            '[uglier.chained.property.lookup]'
-        ].sort());
+  assert.deepEqual(
+    detect(read('properties.js')).map(function (node) { return '[' + node.nodes.map(buildQualifiedVariableName) + ']'; }),
+    [
+      '[simple_g]',
+      '[qualified_g]',
+      '[ugly.chained.methodCall,ugly.chained.lookup]',
+      '[uglier.chained.property.lookup]'
+    ].sort()
+  );
 });
 test('reserved-words.js - check we do not force into strict mode', function () {
-  assert.deepEqual(detect(read('reserved-words.js')).map(function (node) { return node.name; }), ['console']);
+  assert.deepEqual(detect(read('reserved-words.js')).map(nameOf), ['console']);
 });
 test('rest-argument.js - ES2015 rest argument', function () {
   assert.deepEqual(detect(read('rest-argument.js')), []);
@@ -118,11 +130,11 @@ test('return_hash.js - named argument / parameter', function () {
   assert.deepEqual(detect(read('return_hash.js')), []);
 });
 test('right_hand.js - globals on the right-hand of assignment', function () {
-  assert.deepEqual(detect(read('right_hand.js')).map(function (node) { return node.name; }), [ 'exports', '__dirname', '__filename' ].sort());
+  assert.deepEqual(detect(read('right_hand.js')).map(nameOf), [ 'exports', '__dirname', '__filename' ].sort());
 });
 test('try_catch.js - the exception in a try catch block is a local', function () {
   assert.deepEqual(detect(read('try_catch.js')), []);
 });
 test('this.js - `this` is considered a global', function () {
-  assert.deepEqual(detect(read('this.js')).map(function (node) { return node.name; }), ['this']);
+  assert.deepEqual(detect(read('this.js')).map(nameOf), ['this']);
 });


### PR DESCRIPTION
Destructuring in catch below didn't work right before this PR:

```js
try { }
catch ({ message }) { message; }
```