### PR TITLE
Update acorn to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "acorn": "^6.0.1",
+    "acorn": "^7.1.1",
     "acorn-walk": "^6.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes following error from running `npm audit`:
```
  Moderate        Regular Expression Denial of Service                          

  Package         acorn                                                         

  Patched in      >=7.1.1                                                       

  Dependency of   acorn-globals                                        

  Path            acorn-globals > acorn                               

  More info       https://npmjs.com/advisories/1488  
```