### PR TITLE
fix: globally declared identifiers 

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ function isScope(node) {
   return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'ArrowFunctionExpression' || node.type === 'Program';
 }
 function isBlockScope(node) {
-  return node.type === 'BlockStatement' || isScope(node);
+  // The body of switch statement is a block.
+  return node.type === 'BlockStatement' || node.type === 'SwitchStatement' || isScope(node);
 }
 
 function declaresArguments(node) {

--- a/test/fixtures/globally-declared-identifiers.js
+++ b/test/fixtures/globally-declared-identifiers.js
@@ -8,9 +8,11 @@ a;
 c;
 function d() {}
 d;
+function e() {}
 {
-  function e() {}
   e;
   function f() {}
+  f;
+  function g() {}
 }
-f;
+g;

--- a/test/fixtures/globally-declared-identifiers.js
+++ b/test/fixtures/globally-declared-identifiers.js
@@ -1,0 +1,16 @@
+var a;
+a;
+{
+  var b;
+  b;
+  var c;
+}
+c;
+function d() {}
+d;
+{
+  function e() {}
+  e;
+  function f() {}
+}
+f;

--- a/test/fixtures/switch-statement.js
+++ b/test/fixtures/switch-statement.js
@@ -1,0 +1,6 @@
+switch (3) {
+  case 3:
+    let a;
+}
+
+a;

--- a/test/index.js
+++ b/test/index.js
@@ -138,6 +138,9 @@ test('return_hash.js - named argument / parameter', function () {
 test('right_hand.js - globals on the right-hand of assignment', function () {
   assert.deepEqual(detect(read('right_hand.js')).map(nameOf), [ 'exports', '__dirname', '__filename' ].sort());
 });
+test('switch-statement.js - id in outer scope of switch is a global', function () {
+  assert.deepEqual(detect(read('switch-statement.js')).map(nameOf), ['a']);
+});
 test('try_catch.js - the exception in a try catch block is a local', function () {
   assert.deepEqual(detect(read('try_catch.js')), []);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -98,7 +98,7 @@ test('export-default-anonymous-function.js - export anonymous function as defaul
   assert.deepEqual(detect(read('export-default-anonymous-function.js')), []);
 });
 test('globally-declared-identifiers.js - var and function declaration outside functions create globals', function () {
-  assert.deepEqual(detect(read('globally-declared-identifiers.js'), {inBrowser: true}).map(nameOf), ['a','b','c','d','f']);
+  assert.deepEqual(detect(read('globally-declared-identifiers.js'), {inBrowser: true}).map(nameOf), ['a','b','c','d','e','g']);
 });
 test('import.js - Anything that has been imported is not a global', function () {
   assert.deepEqual(detect(read('import.js')).map(nameOf), ['whatever']);

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,9 @@ test('export-default-anonymous-class.js - export anonymous class as default', fu
 test('export-default-anonymous-function.js - export anonymous function as default', function () {
   assert.deepEqual(detect(read('export-default-anonymous-function.js')), []);
 });
+test('globally-declared-identifiers.js - var and function declaration outside functions create globals', function () {
+  assert.deepEqual(detect(read('globally-declared-identifiers.js'), {inBrowser: true}).map(nameOf), ['a','b','c','d','f']);
+});
 test('import.js - Anything that has been imported is not a global', function () {
   assert.deepEqual(detect(read('import.js')).map(nameOf), ['whatever']);
 });


### PR DESCRIPTION

acorn-globals only finds all accessing of non-declared identifiers as accessing global variables, but in browser context and not in module context, "var" decarations and function declarations both out of all function scopes install new properties into global object. It means that they declare global variables.

```
var a;
a; // global
{
  var b;
  b; // global
  var c;
}
c; // global
function d() {}
d; // global
{
  function e() {}
  e; // local
  function f() {}
}
f; // global
```